### PR TITLE
Add github-actions ecosystem to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,4 +26,17 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"
 


### PR DESCRIPTION
## Summary
- Dependabot was only configured for maven and docker; GitHub Actions used in CI weren't getting automatic version-update PRs.
- Adds a `github-actions` ecosystem entry matching the existing config style.

Part of an org-wide public-repo hygiene pass (Dependabot coverage + branch protection).